### PR TITLE
non-hidl: Remove FINGERPRINT_ERROR_LOCKOUT

### DIFF
--- a/android/hybris/biometry_fp_for_hybris.cpp
+++ b/android/hybris/biometry_fp_for_hybris.cpp
@@ -110,8 +110,6 @@ UHardwareBiometryFingerprintError VendorErrorFilter(int32_t error, int32_t* vend
             return ERROR_CANCELED;
         case FINGERPRINT_ERROR_UNABLE_TO_REMOVE:
             return ERROR_UNABLE_TO_REMOVE;
-        case FINGERPRINT_ERROR_LOCKOUT:
-            return ERROR_LOCKOUT;
         default:
             if (error >= FINGERPRINT_ERROR_VENDOR_BASE) {
                 // vendor specific code.


### PR DESCRIPTION
It's not supported on Android 7.1.1.